### PR TITLE
feat: add PostgreSQL 18 support via Alpine edge build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -122,6 +122,15 @@ jobs:
             type=raw,value=${{ needs.create-release.outputs.version }}-alpine-3-20
             type=raw,value=${{ needs.create-release.outputs.tag }}-alpine-3-20
 
+      - name: Extract metadata for Alpine edge
+        id: meta-alpine-edge
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ needs.create-release.outputs.version }}-alpine-edge
+            type=raw,value=${{ needs.create-release.outputs.tag }}-alpine-edge
+
       - name: Build and push Docker image to Alpine 3.21
         id: build_alpine_3_21
         uses: docker/build-push-action@v6
@@ -152,6 +161,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push Docker image to Alpine edge
+        id: build_alpine_edge
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile.dump
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            ALPINE_VERSION=edge
+          tags: ${{ steps.meta-alpine-edge.outputs.tags }}
+          labels: ${{ steps.meta-alpine-edge.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Generate artifact attestation for Alpine 3.21
         uses: actions/attest-build-provenance@v2
         with:
@@ -164,4 +188,11 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build_alpine_3_20.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for Alpine edge
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build_alpine_edge.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -128,6 +128,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=raw,value=alpine-edge
             type=raw,value=${{ needs.create-release.outputs.version }}-alpine-edge
             type=raw,value=${{ needs.create-release.outputs.tag }}-alpine-edge
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -171,7 +171,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            ALPINE_VERSION=edge
+            ALPINE_VERSION=edge@sha256:9a341ff2287c54b86425cbee0141114d811ae69d88a36019087be6d896cef241
           tags: ${{ steps.meta-alpine-edge.outputs.tags }}
           labels: ${{ steps.meta-alpine-edge.outputs.labels }}
           cache-from: type=gha

--- a/docker/scripts/install_db_clients.sh
+++ b/docker/scripts/install_db_clients.sh
@@ -3,7 +3,7 @@ set -e
 
 # Script to install database clients dynamically
 # Based on environment variables:
-# - POSTGRES_VERSION: PostgreSQL client version (13, 14, 15, 16, 17)
+# - POSTGRES_VERSION: PostgreSQL client version (13, 14, 15, 16, 17, 18)
 # - MYSQL_VERSION: MySQL client version (8.0)
 # - MARIADB_VERSION: MariaDB client version (10.11, 11.4)
 # - MongoDB tools: installed without version pinning (mongodump, mongorestore)
@@ -31,13 +31,13 @@ install_postgresql_client() {
     echo "Installing PostgreSQL client version $version..."
     
     case "$version" in
-        "13"|"14"|"15"|"16"|"17")
+        "13"|"14"|"15"|"16"|"17"|"18")
             apk add --no-cache postgresql${version}-client
             echo "PostgreSQL client $version installed successfully"
             ;;
         *)
             echo "Error: Unsupported PostgreSQL version: $version"
-            echo "Supported versions: 13, 14, 15, 16, 17"
+            echo "Supported versions: 13, 14, 15, 16, 17, 18"
             exit 1
             ;;
     esac

--- a/examples/version-compatibility.md
+++ b/examples/version-compatibility.md
@@ -83,6 +83,7 @@ The container will now:
 - `15` - For PostgreSQL 15.x servers
 - `16` - For PostgreSQL 16.x servers
 - `17` - For PostgreSQL 17.x servers
+- `18` - For PostgreSQL 18.x servers
 
 ### MySQL/MariaDB
 - `8.0` - For MySQL 8.0 servers


### PR DESCRIPTION
## What's Changed                                                                                                                                          
                                                                                                                                                             
  PostgreSQL 18 is only available in Alpine edge, which is not included in                                                                                   
  the existing builds (3.20 and 3.21). This PR adds a new image build                                                                                        
  targeting Alpine edge to support pg_dump/pg_restore for PostgreSQL 18.x servers.
                                                                                                                                                             
  ### Changes                                 
  - Added Alpine edge build to the CI pipeline (metadata + build + attestation)                                                                              
  - Updated `install_db_clients.sh` to accept `POSTGRES_VERSION=18`
  - Updated `examples/version-compatibility.md` to document version 18                                                                                       
                                          
  ### New image tag                                                                                                                                          
  Users running PostgreSQL 18 should use the `-alpine-edge` tagged image:                                                                                    
                                                                                                                                                             
  ghcr.io/cloudscript-technology/dumpscript:{version}-alpine-edge                                                                                            
                                          
  ### Supported versions per image                                                                                                                           
  | Image tag | PostgreSQL versions |                                                                                                                        
  |---|---|                                                                                                                                                  
  | `-alpine-3.20` | 14, 15, 16, 17 |                                                                                                                        
  | `-alpine-3.21` | 15, 16, 17 |
  | `-alpine-edge` | 16, 17, **18** |   