### PR TITLE
fix/s3-storage-class-configurable

### DIFF
--- a/docker/scripts/storage_utils.sh
+++ b/docker/scripts/storage_utils.sh
@@ -131,7 +131,9 @@ _storage_upload_flags() {
             echo "--s3-upload-cutoff=$STORAGE_UPLOAD_CUTOFF"
             echo "--s3-chunk-size=$STORAGE_CHUNK_SIZE"
             echo "--s3-upload-concurrency=$STORAGE_UPLOAD_CONCURRENCY"
-            echo "--s3-storage-class=STANDARD_IA"
+            if [ -n "${S3_STORAGE_CLASS:-}" ]; then
+                echo "--s3-storage-class=${S3_STORAGE_CLASS}"
+            fi
             ;;
         azure)
             echo "--azureblob-upload-cutoff=$STORAGE_UPLOAD_CUTOFF"


### PR DESCRIPTION
Replace hardcoded STANDARD_IA storage class in storage_utils.sh with an optional S3_STORAGE_CLASS environment variable. When unset or empty, no --s3-storage-class flag is passed to rclone, fixing InvalidStorageClass errors on GCS and other S3-compatible backends that don't support AWS-specific storage classes.