### PR TITLE
Feat/local tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cursorignore
 web
+**/.env

--- a/docker/scripts/storage_utils.sh
+++ b/docker/scripts/storage_utils.sh
@@ -131,7 +131,9 @@ _storage_upload_flags() {
             echo "--s3-upload-cutoff=$STORAGE_UPLOAD_CUTOFF"
             echo "--s3-chunk-size=$STORAGE_CHUNK_SIZE"
             echo "--s3-upload-concurrency=$STORAGE_UPLOAD_CONCURRENCY"
-            echo "--s3-storage-class=STANDARD_IA"
+            if [ -n "${S3_STORAGE_CLASS:-}" ]; then
+                echo "--s3-storage-class=${S3_STORAGE_CLASS}"
+            fi
             ;;
         azure)
             echo "--azureblob-upload-cutoff=$STORAGE_UPLOAD_CUTOFF"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dumpscript-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test:gcs": "docker compose -f tests/gcs/docker-compose.yml --env-file tests/gcs/.env up --build --abort-on-container-exit --exit-code-from dumpscript",
+    "test:aws": "docker compose -f tests/aws/docker-compose.yml --env-file tests/aws/.env up --build --abort-on-container-exit --exit-code-from dumpscript",
+    "test:azure": "docker compose -f tests/azure/docker-compose.yml --env-file tests/azure/.env up --build --abort-on-container-exit --exit-code-from dumpscript",
+    "test:gcs:down": "docker compose -f tests/gcs/docker-compose.yml down -v",
+    "test:aws:down": "docker compose -f tests/aws/docker-compose.yml down -v",
+    "test:azure:down": "docker compose -f tests/azure/docker-compose.yml down -v"
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,72 @@
+# Tests
+
+Testes de integração do dumpscript contra os providers de storage reais.
+
+## Estrutura
+
+```
+tests/
+├── gcs/      # Google Cloud Storage via S3-compatible API (HMAC)
+├── aws/      # AWS S3
+└── azure/    # Azure Blob Storage
+```
+
+## Como usar
+
+Os comandos são executados a partir da **raiz do repositório**.
+
+### 1. Copie o .env.example para .env e preencha as credenciais
+
+```bash
+cp tests/gcs/.env.example tests/gcs/.env
+cp tests/aws/.env.example tests/aws/.env
+cp tests/azure/.env.example tests/azure/.env
+```
+
+### 2. Execute o teste do provider desejado
+
+```bash
+npm run test:gcs
+npm run test:aws
+npm run test:azure
+```
+
+### 3. Limpe os containers após o teste (opcional)
+
+```bash
+npm run test:gcs:down
+npm run test:aws:down
+npm run test:azure:down
+```
+
+---
+
+## GCS
+
+Usa a [API S3-compatível do GCS com HMAC keys](https://cloud.google.com/storage/docs/interoperability).
+
+**Pré-requisitos:**
+- Habilite a interoperabilidade em: GCP Console → Storage → Settings → Interoperability
+- Crie um HMAC key para a Service Account desejada
+- O bucket deve existir previamente
+
+> `S3_STORAGE_CLASS` **não deve ser definido** para GCS. O GCS rejeita classes da AWS (`STANDARD_IA`, etc.) via S3-compat API.
+
+---
+
+## AWS S3
+
+**Pré-requisitos:**
+- IAM User com permissões: `s3:PutObject`, `s3:GetObject`, `s3:ListBucket`, `s3:DeleteObject`
+- O bucket deve existir previamente
+
+Para temporary credentials (STS), defina também `AWS_SESSION_TOKEN` no `.env`.
+
+---
+
+## Azure Blob Storage
+
+**Pré-requisitos:**
+- Storage Account criada no Azure
+- Container criado previamente
+- Storage Account Key **ou** SAS Token com permissões `Read`, `Write`, `List`, `Delete`

--- a/tests/aws/.env.example
+++ b/tests/aws/.env.example
@@ -1,0 +1,36 @@
+# =============================================
+# AWS S3
+# =============================================
+
+# --- AWS Credentials ---
+# Opção 1: IAM User com Access Key
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=your-secret
+
+# Opção 2: Temporary credentials (STS/AssumeRole)
+# AWS_ACCESS_KEY_ID=ASIA...
+# AWS_SECRET_ACCESS_KEY=your-secret
+# AWS_SESSION_TOKEN=your-session-token
+
+# --- AWS S3 Bucket ---
+AWS_REGION=us-east-1
+S3_BUCKET=your-s3-bucket-name
+S3_PREFIX=postgres/testdb
+
+# Storage class AWS nativa — deixar vazio para usar padrão do bucket
+# Opções válidas: STANDARD, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE
+S3_STORAGE_CLASS=STANDARD_IA
+
+# --- Database ---
+DB_TYPE=postgresql
+POSTGRES_VERSION=18
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=testdb
+
+# --- Backup ---
+PERIODICITY=daily
+RETENTION_DAYS=7
+DUMP_OPTIONS=--no-owner --format=custom

--- a/tests/aws/docker-compose.yml
+++ b/tests/aws/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  dumpscript:
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.dump
+      args:
+        ALPINE_VERSION: edge
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      STORAGE_BACKEND: s3
+      AWS_REGION: ${AWS_REGION}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+      S3_BUCKET: ${S3_BUCKET}
+      S3_PREFIX: ${S3_PREFIX}
+      S3_STORAGE_CLASS: ${S3_STORAGE_CLASS:-STANDARD_IA}
+      DB_TYPE: ${DB_TYPE}
+      POSTGRES_VERSION: ${POSTGRES_VERSION}
+      DB_HOST: postgres
+      DB_PORT: ${DB_PORT}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      PERIODICITY: ${PERIODICITY:-daily}
+      RETENTION_DAYS: ${RETENTION_DAYS:-7}
+      DUMP_OPTIONS: ${DUMP_OPTIONS:---no-owner --format=custom}

--- a/tests/azure/.env.example
+++ b/tests/azure/.env.example
@@ -1,0 +1,35 @@
+# =============================================
+# Azure Blob Storage
+# =============================================
+
+# --- Azure Credentials ---
+# Opção 1: Storage Account Key
+# Encontre em: Azure Portal > Storage Account > Access keys
+AZURE_STORAGE_ACCOUNT=yourstorageaccount
+AZURE_STORAGE_KEY=your-base64-storage-key==
+
+# Opção 2: SAS Token (alternativa à key)
+# AZURE_STORAGE_ACCOUNT=yourstorageaccount
+# AZURE_STORAGE_SAS_TOKEN=https://yourstorageaccount.blob.core.windows.net/?sv=...
+
+# Opção 3: Azurite (emulador local) — descomente e use com profile azurite
+# AZURE_STORAGE_ACCOUNT=devstoreaccount1
+# AZURE_STORAGE_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+
+# --- Azure Container ---
+AZURE_STORAGE_CONTAINER=your-container-name
+AZURE_STORAGE_PREFIX=postgres/testdb
+
+# --- Database ---
+DB_TYPE=postgresql
+POSTGRES_VERSION=18
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=testdb
+
+# --- Backup ---
+PERIODICITY=daily
+RETENTION_DAYS=7
+DUMP_OPTIONS=--no-owner --format=custom

--- a/tests/azure/docker-compose.yml
+++ b/tests/azure/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  dumpscript:
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.dump
+      args:
+        ALPINE_VERSION: edge
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      STORAGE_BACKEND: azure
+      AZURE_STORAGE_ACCOUNT: ${AZURE_STORAGE_ACCOUNT}
+      AZURE_STORAGE_KEY: ${AZURE_STORAGE_KEY:-}
+      AZURE_STORAGE_SAS_TOKEN: ${AZURE_STORAGE_SAS_TOKEN:-}
+      AZURE_STORAGE_CONTAINER: ${AZURE_STORAGE_CONTAINER}
+      AZURE_STORAGE_PREFIX: ${AZURE_STORAGE_PREFIX}
+      DB_TYPE: ${DB_TYPE}
+      POSTGRES_VERSION: ${POSTGRES_VERSION}
+      DB_HOST: postgres
+      DB_PORT: ${DB_PORT}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      PERIODICITY: ${PERIODICITY:-daily}
+      RETENTION_DAYS: ${RETENTION_DAYS:-7}
+      DUMP_OPTIONS: ${DUMP_OPTIONS:---no-owner --format=custom}

--- a/tests/gcs/.env.example
+++ b/tests/gcs/.env.example
@@ -1,0 +1,34 @@
+# =============================================
+# GCS via S3-compatible API (HMAC credentials)
+# =============================================
+# Gere as credenciais em: GCP Console > Storage > Settings > Interoperability
+# Habilite "Interoperability" e crie um HMAC key para sua Service Account
+
+# --- GCS Credentials (HMAC) ---
+AWS_ACCESS_KEY_ID=GOOG1E...
+AWS_SECRET_ACCESS_KEY=your-hmac-secret
+
+# --- GCS Bucket ---
+AWS_REGION=us-central1
+S3_BUCKET=your-gcs-bucket-name
+S3_PREFIX=postgres/testdb
+
+# Endpoint GCS S3-compat — não alterar
+AWS_S3_ENDPOINT_URL=https://storage.googleapis.com
+
+# --- Database ---
+DB_TYPE=postgresql
+POSTGRES_VERSION=18
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=testdb
+
+# --- Backup ---
+PERIODICITY=daily
+RETENTION_DAYS=7
+DUMP_OPTIONS=--no-owner --format=custom
+
+# --- S3_STORAGE_CLASS deixado vazio para GCS (GCS não suporta STANDARD_IA) ---
+# S3_STORAGE_CLASS=

--- a/tests/gcs/docker-compose.yml
+++ b/tests/gcs/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  dumpscript:
+    build:
+      context: ../../docker
+      dockerfile: Dockerfile.dump
+      args:
+        ALPINE_VERSION: edge
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      # GCS via S3-compat: sem storage class (GCS não suporta STANDARD_IA)
+      STORAGE_BACKEND: s3
+      AWS_S3_ENDPOINT_URL: ${AWS_S3_ENDPOINT_URL}
+      AWS_REGION: ${AWS_REGION}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      S3_BUCKET: ${S3_BUCKET}
+      S3_PREFIX: ${S3_PREFIX}
+      DB_TYPE: ${DB_TYPE}
+      POSTGRES_VERSION: ${POSTGRES_VERSION}
+      DB_HOST: postgres
+      DB_PORT: ${DB_PORT}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      PERIODICITY: ${PERIODICITY:-daily}
+      RETENTION_DAYS: ${RETENTION_DAYS:-7}
+      DUMP_OPTIONS: ${DUMP_OPTIONS:---no-owner --format=custom}
+      # S3_STORAGE_CLASS não definido = sem --s3-storage-class no rclone


### PR DESCRIPTION
Adiciona testes de integração local para validar o dump e upload contra os três providers de storage reais: GCS, AWS S3 e Azure Blob Storage.

Cada provider tem sua própria pasta em tests/ com um docker-compose.yml e um .env.example. Os composes sobem um PostgreSQL 18 local, buildam a imagem do dumpscript com Alpine edge (necessário para o cliente pg18) e executam o dump completo contra o storage real.